### PR TITLE
Add basic getting-started docs and API reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
-# Persistent, reactive, and synchronized data for Roblox Luau.
+# DataService
 
-https://leifstout.github.io/dataService/
+Persistent, auto-replicated, and observable player data for Roblox Luau.
+
+## Documentation
+
+- **Getting started:** https://leifstout.github.io/dataService/docs/intro
+- **Complete API reference:** https://leifstout.github.io/dataService/api
+
+If you're new to the package, start with the getting started guide and then use the API reference for full method/type details.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -3,3 +3,90 @@ sidebar_position: 1
 ---
 
 # Getting Started with DataService
+
+DataService provides a simple way to manage player data on the server while keeping clients in sync automatically.
+
+## 1) Install
+
+Add DataService to your `wally.toml`:
+
+```toml
+[dependencies]
+DataService = "leifstout/dataService@^1.0.0"
+```
+
+Then run:
+
+```bash
+wally install
+```
+
+## 2) Define your data template
+
+Create a module for your default player data:
+
+```lua
+return {
+	currency = 0,
+	level = 1,
+	xp = 0,
+	inventory = {},
+	settings = {
+		musicVolume = 0.5,
+		sfxVolume = 0.5,
+	},
+}
+```
+
+> Keep values JSON-compatible (numbers, strings, booleans, arrays, dictionaries).
+
+## 3) Initialize on the server
+
+In a server script, initialize DataService once:
+
+```lua
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Packages = ReplicatedStorage.Packages
+
+local DataService = require(Packages.DataService).server
+local dataTemplate = require(script.Parent.dataTemplate)
+
+DataService:init({
+	template = dataTemplate,
+	profileStoreIndex = "Default",
+})
+```
+
+## 4) Read and react on the client
+
+Use the client module to read data and subscribe to changes:
+
+```lua
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Packages = ReplicatedStorage.Packages
+
+local DataService = require(Packages.DataService).client
+
+local currency = DataService:get({ "currency" })
+print("Currency:", currency)
+
+DataService:getChangedSignal({ "currency" }):Connect(function(newValue)
+	print("Currency updated:", newValue)
+end)
+```
+
+## 5) Update data on the server
+
+When game logic changes player values, mutate data on the server:
+
+```lua
+-- Example: add currency when a player completes a reward
+DataService:update(player, { "currency" }, function(current)
+	return current + 100
+end)
+```
+
+## Next steps
+
+- Browse the **complete API reference**: https://leifstout.github.io/dataService/api
+- Review options like `useMock`, `dontSave`, and `resetData` in the server API.


### PR DESCRIPTION
### Motivation

- Provide an onboarding path so new users can quickly install and initialize the package and find the full API reference. 
- Surface concise examples for both server and client usage to reduce friction when integrating `DataService` into a project.

### Description

- Update `README.md` to include a short project description and direct links to the getting-started guide and the complete API reference. 
- Add `docs/intro.md` with a full Getting Started guide that covers installation (`wally.toml`), creating a data template, server initialization (`DataService:init`), client reads/subscriptions (`DataService:get`, `DataService:getChangedSignal`), and a server-side update example (`DataService:update`).
- Include explicit links to the complete API reference from both the README and the intro document.

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff issues, and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f94e6468c83258eeeda9e643e4fd1)